### PR TITLE
Add `is_active` column and remove `is_correct` column from `userprogr…

### DIFF
--- a/database/itpec_exam_review.sql
+++ b/database/itpec_exam_review.sql
@@ -3,7 +3,7 @@
 -- https://www.phpmyadmin.net/
 --
 -- Host: 127.0.0.1
--- Generation Time: Oct 18, 2024 at 09:59 AM
+-- Generation Time: Oct 19, 2024 at 05:34 PM
 -- Server version: 10.4.32-MariaDB
 -- PHP Version: 8.0.30
 
@@ -123,7 +123,7 @@ CREATE TABLE `userprogress` (
   `user_id` int(10) UNSIGNED NOT NULL,
   `question_id` int(10) UNSIGNED NOT NULL,
   `selected_answer_id` int(10) UNSIGNED NOT NULL,
-  `is_correct` tinyint(1) NOT NULL DEFAULT 0,
+  `is_active` tinyint(1) NOT NULL DEFAULT 1,
   `attempted_at` timestamp NOT NULL DEFAULT current_timestamp()
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 


### PR DESCRIPTION
…ess`

- Added an `is_active` column to the `userprogress` table to enable soft deletions.
- Removed the redundant `is_correct` column, as correctness can be derived from the answer data.

These changes streamline the `userprogress` table by eliminating unnecessary columns and providing a more flexible approach for tracking progress resets without data loss.