### PR TITLE
fix: add warning() method to Logger class

### DIFF
--- a/app/core/Logger.php
+++ b/app/core/Logger.php
@@ -86,6 +86,17 @@ class Logger
     }
 
     /**
+     * Logs a warning message.
+     *
+     * @param string $message The message to log.
+     * @return void
+     */
+    public function warning(string $message): void
+    {
+        $this->writeLog("WARNING", $message);
+    }
+
+    /**
      * Writes a log entry to the log file.
      *
      * @param string $level The log level (e.g., INFO, ERROR).


### PR DESCRIPTION
- Added a warning() method to the Logger class to support logging warning level messages, resolving the undefined method error in UidCookieMiddleware.php.